### PR TITLE
Upgrade to AWS SDK V3

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,5 +1,4 @@
 let s3Client
-let putObjectCommand
 
 module.exports.reportToS3 = async function (
     profilingData,
@@ -15,24 +14,33 @@ module.exports.reportToS3 = async function (
         Key: `${pathPrefix}${functionName}/${awsRequestId}/${fileName}.cpuprofile`,
     }
 
-    if (!s3Client) {
-        if (isSDKV3()) {
-            const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3'); 
-            s3Client = new S3Client();
-            putObjectCommand = new PutObjectCommand(params);
-        } else {
-            const S3 = require('aws-sdk/clients/s3');
-            s3Client = new S3();
-        }
-    }
-
     return isSDKV3()
-        ? s3Client.send(putObjectCommand)
-        : s3Client.putObject(params).promise();
+        ? reportWithSDKV3(params)
+        : reportWithSDKV2(params);
 }
 
 // Starting from Node18, Lambda includes JS SDK V3
 function isSDKV3() {
     const nodeVersion = process.versions.node.split('.')[0];
     return nodeVersion >= 18;
+}
+
+function reportWithSDKV3(params) {
+    const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3'); 
+
+    if (!s3Client) {    
+        s3Client = new S3Client();
+    }
+
+    const putObjectCommand = new PutObjectCommand(params);
+    return s3Client.send(putObjectCommand);
+}
+
+function reportWithSDKV2(params) {
+    if (!s3Client) {    
+        const S3 = require('aws-sdk/clients/s3');
+        s3Client = new S3();
+    }
+
+    return s3Client.putObject(params).promise();   
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,3 +1,5 @@
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3"); 
+
 let s3Client
 
 module.exports.reportToS3 = async function (
@@ -9,13 +11,15 @@ module.exports.reportToS3 = async function (
     awsRequestId
 ) {
     if (!s3Client) {
-        const S3 = require('aws-sdk/clients/s3')
-        s3Client = new S3()
+        s3Client = new S3Client();
     }
+
     const params = {
         Body: JSON.stringify(profilingData),
         Bucket: bucketName,
         Key: `${pathPrefix}${functionName}/${awsRequestId}/${fileName}.cpuprofile`,
     }
-    return s3Client.putObject(params).promise()
+    const putObjectCommand = new PutObjectCommand(params);
+    
+    return await s3Client.send(putObjectCommand)
 }


### PR DESCRIPTION
### Notes

Upgrade AWS SDK to V3 since V2 will enter maintenance mode in 2023. Ref: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/

### Testing
Tested by running a CPU profiler on Lambda with Node18 and Node16 to test both JS SDK versions.